### PR TITLE
Optimization through computing Piece symmetries

### DIFF
--- a/Board.java
+++ b/Board.java
@@ -85,8 +85,21 @@ public class Board {
 		ArrayList<Piece> answer = new ArrayList<Piece>();
 		// loop through root nodes
 		for(int i = 0; i < p.getSize(); i++) {
+			
+			// set parameters according to symmetries
+			int end = 8; 
+			int delta = 1;
+			if(p.has90DegRotSymmetry()) {
+				end = 2;
+			} else if(p.has180DegRotSymmetry()) {
+				end = 4;
+			}
+			if(p.hasMirrorSymmetry()) {
+				delta = 2;
+			}
+			
 			// loop through orientations
-			for(int j = 0; j < 8; j++) {
+			for(int j = 0; j < end; j+=delta) {
 				Piece transformed = p.getTransformed(s, i, j);
 				if (transformed.doesFit(this)) {
 					answer.add(transformed);

--- a/BoardSetUp.java
+++ b/BoardSetUp.java
@@ -87,7 +87,7 @@ public class BoardSetUp {
 	 *     3 3
 	 ******************
 	 *
-	 * orientations (CW):
+	 * orientations (CCW):
 	 * 0 = 0 degrees
 	 * 1 = 90 degrees
 	 * 2 = 180 degrees

--- a/PointCloud2D.java
+++ b/PointCloud2D.java
@@ -1,0 +1,121 @@
+package Main;
+
+import java.awt.geom.Point2D;
+import java.awt.geom.Point2D.Double;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class PointCloud2D extends ArrayList<Point2D.Double> {
+
+	private static final long serialVersionUID = 1L;
+	
+	public PointCloud2D() {
+		super();
+	}
+	
+	public PointCloud2D(int size) {
+		super(size);
+	}
+	
+	public PointCloud2D(Point2D.Double[] points) {
+		super(points.length);
+		for(Point2D.Double p: points) {
+			this.add(p);
+		}
+	}
+	
+	// deep copy the object
+	public PointCloud2D(PointCloud2D points) {
+		super(points.size());
+		for(Point2D.Double p: points) {
+			this.add((Double) p.clone());
+		}
+	}
+	
+	// test for equality
+	@Override
+	public boolean equals(Object other) {
+		if(!(other instanceof PointCloud2D)) {
+			return false;
+		}
+		PointCloud2D points = (PointCloud2D)other;
+		
+		if(points.size() != this.size()) {
+			return false;
+		}
+		
+		Iterator<Double> i = this.iterator();
+		while(i.hasNext()) {
+			Point2D.Double p = (Point2D.Double)i.next();
+			if(!points.contains(p)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	// translates each point in the list by a given x and y value
+	public void translate(double dx, double dy) {
+		Iterator<Double> i = iterator();
+		while(i.hasNext()) {
+			Point2D.Double p = i.next();
+			p.setLocation(p.getX() + dx, p.getY() + dy);
+		}
+	}
+	
+	// rotates each point about the origin by the given theta number of degrees
+	public void rotate(double theta) {
+		double sine, cosine;
+		sine = Math.sin(Math.toRadians(theta));
+		cosine = Math.cos(Math.toRadians(theta));
+		
+		// fixing precision errors
+		if(theta%360 == 180) {
+			sine = 0;
+		}
+		if(Math.abs(theta)%180 == 90) { 
+			cosine = 0;
+		}
+		
+		Iterator<Double> i = iterator();
+		while(i.hasNext()) {
+			Point2D.Double p = i.next();
+			p.setLocation(p.x*cosine - p.y*sine, p.x*sine + p.y*cosine);
+		}
+	}
+	
+	// reflects each point over the given line of reflection
+	// line passing through origin at angle theta relative to x-axis
+	public void reflect(double theta) {
+		double sine, cosine;
+		sine = Math.sin(Math.toRadians(2*theta));
+		cosine = Math.cos(Math.toRadians(2*theta));
+		
+		// fixing precision errors
+		if(Math.abs(theta)%180 == 90) {
+			sine = 0;
+		}
+		if(Math.abs(theta)%90 == 45) { 
+			cosine = 0;
+		}
+		
+		Iterator<Double> i = iterator();
+		while(i.hasNext()) {
+			Point2D.Double p = i.next();
+			p.setLocation(p.x*cosine + p.y*sine, p.x*sine - p.y*cosine);
+		}
+	}
+	
+	// return the center of mass of the points
+	public Point2D.Double getCenterOfMass() {
+		double sumX, sumY;
+		sumX = sumY = 0;
+		Iterator<Double> i = iterator();
+		while(i.hasNext()) {
+			Point2D.Double p = i.next();
+			sumX += p.getX();
+			sumY += p.getY();
+		}
+		return new Point2D.Double(sumX/size(), sumY/size());
+	}
+}

--- a/Solver.java
+++ b/Solver.java
@@ -42,7 +42,7 @@ public class Solver {
 	// returns a list of piece locations that fill the board
 	public static ArrayList<Piece> solve(Board bCurrent, PieceList lCurrent) {
 		// base case
-		if (bCurrent.size() == 0) {
+		if (lCurrent.size() == 0) {
 			return new ArrayList<Piece>();
 		}
 		
@@ -53,6 +53,13 @@ public class Solver {
 		// loop through all the pieces
 		while (lCurrent.hasNext()) {
 			Piece p = lCurrent.getNext();
+			
+			/*if(lCurrent.size() == 12) {
+				System.out.println(p);
+			}
+			if(lCurrent.size() == 11) {
+				System.out.println("\t" + p);
+			}*/
 			
 			// loop across all orientations of this piece
 			ArrayList<Piece> orientations = bCurrent.fit(p, sCurrent);
@@ -85,7 +92,7 @@ public class Solver {
 	
 	// returns how many ways the given piece list can fill the given board
 	public static int solutions(Board bCurrent, PieceList lCurrent) {
-		System.out.println(lCurrent.size());
+		//System.out.println(lCurrent.size());
 		
 		// base case
 		if (bCurrent.size() == 0) {
@@ -100,6 +107,12 @@ public class Solver {
 		// loop through all the pieces
 		while (lCurrent.hasNext()) {
 			Piece p = lCurrent.getNext();
+			/*if(lCurrent.size() == 11) {
+				System.out.println(p);
+			}
+			if(lCurrent.size() == 10) {
+				System.out.println("\t" + p);
+			}*/
 			
 			// loop across all orientations of this piece
 			ArrayList<Piece> orientations = bCurrent.fit(p, sCurrent);
@@ -196,7 +209,7 @@ public class Solver {
 				new Point(0,1), new Point(2,1)};
 		Point[] mint = {new Point(0,0), new Point(0,1), new Point(0,2),
 				new Point(1,0), new Point(1,1)};
-		Point[] cyan = {new Point(0,0), new Point(1,0), new Point(1,1)};
+		Point[] cyan = {new Point(0,0), new Point(1,0), new Point(0,1)};
 		Point[] indigo = {new Point(0,0), new Point(1,0), new Point(1,1),
 				new Point(1,2), new Point(2,2)};
 		Point[] pink = {new Point(0,0), new Point(0,1), new Point(0,2),

--- a/Solver.java
+++ b/Solver.java
@@ -42,7 +42,7 @@ public class Solver {
 	// returns a list of piece locations that fill the board
 	public static ArrayList<Piece> solve(Board bCurrent, PieceList lCurrent) {
 		// base case
-		if (lCurrent.size() == 0) {
+		if (bCurrent.size() == 0) {
 			return new ArrayList<Piece>();
 		}
 		


### PR DESCRIPTION
Fixes Issues:
- Solver algorithm repeated work when more than one Piece orientation filled the same slots - caused slow down of recursive algorithm

Features:
- Piece class includes three new boolean flags - computed upon construction - which catalogue the symmetries of the Piece
- setSymmetries() method called by the public constructor. Performs transformations on the Piece points and sets the flag to true if the given transformation results in the same points as the original
- helper methods for setSymmetries() method in Piece class
- new class PointCloud2D extends an ArrayList of 2D Points of double precision - handles the simultaneous transformations of the given points, and can also compute the center of mass of all the points
- add code to fit() method of Board class to check boolean symmetry flags of the current Piece and not loop over redundant orientations

Notes:
- change made to orientation scheme in Board fit() method and Piece transform() method. Rotations are now: 0 deg = {0,1}, 90 deg = {2,3}, 180 deg = {4,5}, 270 deg = {6,7}; odd numbers mean mirrored version of corresponding rotation.
- some parts of existing program call for the copying of an existing Piece instance, but performing the symmetry finding algorithm in these cases would be extraneous since the flags can just be copied. Therefore, a new private "copy" constructor is added to the Piece class to handle this need
- imprecision in the java double type sometimes causes specific combinations of points to give wrong answers in the symmetry finding algorithm - one such case was the previous configuration of the cyan Piece, however the modified version of the same collection of points does not have this issue

Other Changes:
- correction to comment in BoardSetUp class: rotation of board pieces is counter-clockwise from user perspective